### PR TITLE
start UID assignment at 1050 instead of 150

### DIFF
--- a/obol/obol.py
+++ b/obol/obol.py
@@ -241,7 +241,7 @@ class Obol:
 
     def _next_gid(self, _groups):
         idlist = [g["gidNumber"] for g in _groups or []]
-        return self._next_id(idlist, 150, 10000)
+        return self._next_id(idlist, 1050, 10000)
 
     def _user_show_by_uid(self, uid, _users=None):
         """Show system user details"""


### PR DESCRIPTION
Obol by default creates new users starting at UID 150, which, on most Linuxes, is reserved for system services. This commit changes that to UID 1050. Obol uses the same number for GIDs for new groups, so it seems like this is the intended number.