### PR TITLE
Create home dir by copying /etc/skel

### DIFF
--- a/obol.conf
+++ b/obol.conf
@@ -2,6 +2,7 @@
 
 home = /trinity/home
 shell = /bin/bash
+skel = /etc/skel
 
 [ldap]
 

--- a/obol/obol.py
+++ b/obol/obol.py
@@ -36,6 +36,7 @@ import json
 import logging
 import os
 import secrets
+import shutil
 import sys
 import time
 
@@ -411,6 +412,7 @@ class Obol:
         groups=None,
         home=None,
         expire=None,
+        skel=None,
         **kwargs,
     ):
         """Add a user to the LDAP directory"""
@@ -469,6 +471,7 @@ class Obol:
         sn = sn or username
         home = home or f"{self.config.get('users', 'home')}/{username}"
         shell = shell or self.config.get("users", "shell")
+        skel = skel or self.config.get('users', 'skel', fallback='/etc/skel')
 
         if (expire is not None) and (expire != "-1"):
             expire = str(int(expire) + int(time.time() / 86400))
@@ -533,8 +536,10 @@ class Obol:
 
         # Create the user's home directory
         if not os.path.exists(home):
-            os.mkdir(home)
-            os.chown(home, int(uid), int(gid))
+            shutil.copytree(skel, home, symlinks=True)
+            for dirpath, dirnames, filenames, dir_fd in os.fwalk(home, follow_symlinks=False):
+                for n in dirnames + filenames:
+                    os.chown(n, int(uid), int(gid), dir_fd=dir_fd, follow_symlinks=False)
         else:
             home_folder_uid = int(os.stat(home).st_uid)
             if home_folder_uid != int(uid):
@@ -1017,6 +1022,7 @@ def run():
         ),
     )
     user_addsubcommand.add_argument("--home", metavar="HOME")
+    user_addsubcommand.add_argument("--skel", metavar="SKEL_DIR")
 
     # User modify command
     user_modifysubcommand = user_subcommands.add_parser(

--- a/obol/obol.py
+++ b/obol/obol.py
@@ -27,17 +27,18 @@ __email__ = "diego.sonaglia@clustervision.com"
 __status__ = "Development"
 
 
+import argparse
+import base64
+import configparser
+import hashlib
+import inspect
+import json
+import logging
 import os
+import secrets
 import sys
 import time
-import json
-import hashlib
-import base64
-import argparse
-import configparser
-import secrets
-import logging
-import inspect
+
 from getpass import getpass
 from typing import List, Dict, Union
 


### PR DESCRIPTION
Currently obol simply does `mkdir($HOME)`, and nothing more. Tools like `adduser` create the home dir by copying the skeleton directory, typically `/etc/skel`. This pull request makes obol do the same.

For discussion: should obol really only LDAP stuff, or should it also do complicated things with the file system, like this pull request introduces?

Solves https://github.com/clustervision/obol/issues/1.